### PR TITLE
Support 'device_type' property

### DIFF
--- a/src/dtb.zig
+++ b/src/dtb.zig
@@ -157,6 +157,7 @@ pub const Prop = union(enum) {
     Pinctrl2: []u32,
     AssignedClockRates: []u32,
     AssignedClocks: [][]u32,
+    DeviceType: []const u8,
     Unresolved: PropUnresolved,
     Unknown: PropUnknown,
 
@@ -260,6 +261,7 @@ pub const Prop = union(enum) {
                 }
                 try writer.writeByte('>');
             },
+            .DeviceType => |v| try std.fmt.format(writer, "device_type: \"{s}\"", .{v}),
             .Unresolved => |_| try writer.writeAll("UNRESOLVED"),
             .Unknown => |v| try std.fmt.format(writer, "{'}: (unk {} bytes) <{}>", .{ std.zig.fmtEscapes(v.name), v.value.len, std.zig.fmtEscapes(v.value) }),
         }
@@ -352,6 +354,7 @@ pub const Prop = union(enum) {
             .Unknown,
             .ClockFrequency,
             .RegIoWidth,
+            .DeviceType,
             => {},
         }
     }

--- a/src/dtb.zig
+++ b/src/dtb.zig
@@ -390,6 +390,10 @@ test "parse" {
             &.{.{ 1024 * 1024 * 1024, 512 * 1024 * 1024 }},
             qemu_arm64.propAt(&.{"memory@40000000"}, .Reg).?,
         );
+        try testing.expectEqualStrings(
+            "memory",
+            qemu_arm64.propAt(&.{"memory@40000000"}, .DeviceType).?,
+        );
 
         // It has an A53-compatible CPU.
         const compatible = qemu_arm64.propAt(&.{ "cpus", "cpu@0" }, .Compatible).?;

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -130,6 +130,8 @@ const Parser = struct {
             return dtb.Prop{ .Pinctrl2 = try self.integerList(u32, value) };
         } else if (std.mem.eql(u8, name, "assigned-clock-rates")) {
             return dtb.Prop{ .AssignedClockRates = try self.integerList(u32, value) };
+        } else if (std.mem.eql(u8, name, "device_type")) {
+            return dtb.Prop{ .DeviceType = value[0..value.len - 1] };
         } else if (std.mem.eql(u8, name, "reg")) {
             return dtb.Prop{ .Unresolved = .{ .Reg = value } };
         } else if (std.mem.eql(u8, name, "ranges")) {

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -131,7 +131,7 @@ const Parser = struct {
         } else if (std.mem.eql(u8, name, "assigned-clock-rates")) {
             return dtb.Prop{ .AssignedClockRates = try self.integerList(u32, value) };
         } else if (std.mem.eql(u8, name, "device_type")) {
-            return dtb.Prop{ .DeviceType = value[0..value.len - 1] };
+            return dtb.Prop{ .DeviceType = string(value) };
         } else if (std.mem.eql(u8, name, "reg")) {
             return dtb.Prop{ .Unresolved = .{ .Reg = value } };
         } else if (std.mem.eql(u8, name, "ranges")) {
@@ -168,6 +168,10 @@ const Parser = struct {
             @sizeOf(u64) => try integer(u64, value),
             else => error.BadStructure,
         };
+    }
+
+    fn string(value: []const u8) []const u8 {
+        return value[0 .. value.len - 1];
     }
 
     fn stringList(self: *Parser, value: []const u8) Error![][]const u8 {


### PR DESCRIPTION
Allows identifying nodes for main memory or CPUs, e.g:
```
memory@40000000 {
    reg = <0x00 0x40000000 0x00 0x80000000>;
    device_type = "memory";
};
```