### PR TITLE
Fix interrupt cells parsing

### DIFF
--- a/src/dtb.zig
+++ b/src/dtb.zig
@@ -40,12 +40,18 @@ pub const Node = struct {
     }
 
     pub fn interruptCells(node: *Node) ?u32 {
+        if (node.interruptParent()) |ip| {
+            if (ip.prop(.InterruptCells)) |ic| {
+                return ic;
+            } else {
+                return ip.interruptCells();
+            }
+        }
+
         if (node.prop(.InterruptCells)) |ic| {
             return ic;
         }
-        if (node.interruptParent()) |ip| {
-            return ip.interruptCells();
-        }
+
         return null;
     }
 


### PR DESCRIPTION
The issue with the current approach is that the interrupt-cells of the current node is used to decode its own interrupts, rather than for its children.

This fixes the parsing such that as long a node has a parent, we use its interrupt-cells definition.

This was encountered when trying to parse a GPIO device which is a interrupt-controller itself and hence defines 'interrupt-cells' but also has its own interrupts which are defined by the cells of the Generic Interrupt Controller, its parent. The current code decoded its interrupts as if it was its own parent, which is not the case.

The interrupt parsing code could be improved further by checking that the interrupt-cells property does not appear on any devices that are not interrupt controllers or interrupt nexuses (can add a further patch for this later).

I believe this patch makes the interrupt parsing adhere with the spec, see section 2.4 of Device tree specification v0.4 for details.