### PR TITLE
Add 'linux,initrd-start' and `linux,initrd-end' properties

### DIFF
--- a/src/dtb.zig
+++ b/src/dtb.zig
@@ -165,6 +165,8 @@ pub const Prop = union(enum) {
     AssignedClockRates: []u32,
     AssignedClocks: [][]u32,
     DeviceType: []const u8,
+    LinuxInitrdStart: u64,
+    LinuxInitrdEnd: u64,
     Unresolved: PropUnresolved,
     Unknown: PropUnknown,
 
@@ -270,6 +272,8 @@ pub const Prop = union(enum) {
                 try writer.writeByte('>');
             },
             .DeviceType => |v| try std.fmt.format(writer, "device_type: \"{s}\"", .{v}),
+            .LinuxInitrdStart => |v| try std.fmt.format(writer, "linux,initrd-start: 0x{x:0>2}", .{v}),
+            .LinuxInitrdEnd => |v| try std.fmt.format(writer, "linux,initrd-end: 0x{x:0>2}", .{v}),
             .Unresolved => |_| try writer.writeAll("UNRESOLVED"),
             .Unknown => |v| try std.fmt.format(writer, "{'}: (unk {} bytes) <{}>", .{ std.zig.fmtEscapes(v.name), v.value.len, std.zig.fmtEscapes(v.value) }),
         }
@@ -364,6 +368,8 @@ pub const Prop = union(enum) {
             .ClockFrequency,
             .RegIoWidth,
             .DeviceType,
+            .LinuxInitrdStart,
+            .LinuxInitrdEnd,
             => {},
         }
     }

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -134,6 +134,10 @@ const Parser = struct {
             return dtb.Prop{ .AssignedClockRates = try self.integerList(u32, value) };
         } else if (std.mem.eql(u8, name, "device_type")) {
             return dtb.Prop{ .DeviceType = string(value) };
+        } else if (std.mem.eql(u8, name, "linux,initrd-start")) {
+            return dtb.Prop{ .LinuxInitrdStart = try integer(u32, value) };
+        } else if (std.mem.eql(u8, name, "linux,initrd-end")) {
+            return dtb.Prop{ .LinuxInitrdEnd = try integer(u32, value) };
         } else if (std.mem.eql(u8, name, "reg")) {
             return dtb.Prop{ .Unresolved = .{ .Reg = value } };
         } else if (std.mem.eql(u8, name, "ranges")) {


### PR DESCRIPTION
Haven't added a test for these properties since they don't appear the DTBs used for testing. Usually these props don't appear at all but they're useful for my work regarding Linux virtualisation.