### PR TITLE
Fix parsing of `linux,initrd-start` and `linux,initrd-end`

### DIFF
--- a/src/parser.zig
+++ b/src/parser.zig
@@ -135,9 +135,9 @@ const Parser = struct {
         } else if (std.mem.eql(u8, name, "device_type")) {
             return dtb.Prop{ .DeviceType = string(value) };
         } else if (std.mem.eql(u8, name, "linux,initrd-start")) {
-            return dtb.Prop{ .LinuxInitrdStart = try integer(u32, value) };
+            return dtb.Prop{ .LinuxInitrdStart = try u32OrU64(value) };
         } else if (std.mem.eql(u8, name, "linux,initrd-end")) {
-            return dtb.Prop{ .LinuxInitrdEnd = try integer(u32, value) };
+            return dtb.Prop{ .LinuxInitrdEnd = try u32OrU64(value) };
         } else if (std.mem.eql(u8, name, "reg")) {
             return dtb.Prop{ .Unresolved = .{ .Reg = value } };
         } else if (std.mem.eql(u8, name, "ranges")) {


### PR DESCRIPTION
Looks like I got this wrong initially. Linux source code doesn't specify exactly what type these properties are but from looking at the way it's used in Linux source it's always either u32 or u64.