### PR TITLE
Update for Zig 0.14.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "dtb.zig",
+    .name = .dtb,
     .version = "0.0.0",
     .dependencies = .{},
 
@@ -10,4 +10,5 @@
         "LICENSE",
         "README.md",
     },
+    .fingerprint = 0x5870066899dd4281
 }


### PR DESCRIPTION
0.14.0 has some breaking changes that affect this project.

build.zig.zon now requires that the value of 'name' be an enum literal rather than a string, and that it does not have any '.' in the name. The Zig developers have said that calling a package '*.zig' is redundant since it lives in the Zig namespace so I decided to make the name just 'dtb'. The repo/project still being called 'dtb.zig' makes sense to me though.

build.zig.zon now also requires a 'fingerprint', supposed to be a unique identifier for each Zig project that is available as a package. I added the fingerprint by running `zig build` without a fingerprint and then adding whatever the Zig compiler suggested in the error message.