### PR TITLE
Update to Zig 0.15.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,7 +4,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
-    _ = b.addModule("dtb", .{
+    const mod = b.addModule("dtb", .{
         .root_source_file = b.path("src/dtb.zig"),
         .optimize = optimize,
         .target = target,
@@ -13,9 +13,7 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Run the tests");
 
     const unit_tests = b.addTest(.{
-        .root_source_file = b.path("src/dtb.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = mod,
     });
     test_step.dependOn(&b.addRunArtifact(unit_tests).step);
 }


### PR DESCRIPTION
Most of the changes are due to breaking changes with Writers and ArrayLists.

std.fmt.format now becomes writer.print, custom formatting now requires "{f}".

ArrayList defaults to being unmanaged, so now we pass the allocator whenever doing append or deinit etc.